### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: [21.3, 22.0.7, 22.3, 23.0.4, 23.2.7.0, 24.0]
+    container:
+      image: erlang:${{ matrix.otp }}-alpine
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      run: rebar3 compile
+    - name: Tests
+      run: |
+           rebar3 xref
+           rebar3 dialyzer
+           rebar3 ct

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _build
 rebar3.crashdump
 *~
 doc/
+rebar3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # [<img src="https://ipinfo.io/static/ipinfo-small.svg" alt="IPinfo" width="24"/>](https://ipinfo.io/) IPinfo Erlang Client Library
 
+[![Hex.pm Version](https://img.shields.io/hexpm/v/ipinfo.svg)](https://hex.pm/packages/ipinfo)
+
+[![Build Status](https://github.com/ipinfo/erlang/workflows/CI/badge.svg)](https://github.com/ipinfo/erlang/actions)
+
 This is the official Erlang/Elixir client library for the [IPinfo.io](https://ipinfo.io) IP data API, allowing you to lookup your own IP address, or get any of the following details for an IP:
 
 - [IP geolocation data](https://ipinfo.io/ip-geolocation-api) (city, region, country, postal code, latitude and longitude)

--- a/rebar.config
+++ b/rebar.config
@@ -24,3 +24,7 @@
 {ct_opts, [
     {sys_config, "config/test.config"}
 ]}.
+
+{xref_checks, [
+    undefined_functions
+]}.

--- a/src/ipinfo_http.erl
+++ b/src/ipinfo_http.erl
@@ -10,7 +10,7 @@
 
 -spec request_details(ipinfo:t(), binary()) -> {ok, map()} | {error, term()}.
 request_details(#{access_token := AccessToken, base_url := BaseUrl, timeout := Timeout}, Ip) ->
-    Url = build_url(BaseUrl, Ip),
+    Url = binary_to_list(build_url(BaseUrl, Ip)),
     ReqHeaders = build_req_headers(AccessToken),
     Request = {Url, ReqHeaders},
     HTTPOptions = [
@@ -34,6 +34,7 @@ request_details(#{access_token := AccessToken, base_url := BaseUrl, timeout := T
             {error, Reason}
     end.
 
+-spec build_url(binary(), nil | undefined | binary()) -> binary().
 build_url(BaseUrl, Ip) when Ip =:= nil orelse Ip =:= undefined ->
     BaseUrl;
 build_url(BaseUrl, Ip) when is_binary(BaseUrl) andalso is_binary(Ip) ->


### PR DESCRIPTION
**Propose of changes**:
* Added `GH Actions` for OTP versions `21.3`, `22.0.7`, `22.3`, `23.0.4`, `23.2.7.0`,  `24.0`
* Added badges `hex.pm`/`CI build status` into `README`
* Fixed `xref` checking
* Fix Common Tests crash error([httpc:request/4](http://erlang.org/doc/man/httpc.html#http-data-types) expected `list` type, not `binary`):
```erlang
%%% ipinfo_SUITE ==> details_test: FAILED
%%% ipinfo_SUITE ==> {{badmatch,{error,{bad_scheme,<<"http">>}}},
 [{ipinfo_SUITE,details_test,1,
                [{file,"/erlang/test/ipinfo_SUITE.erl"},
                 {line,47}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1754}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1263}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1195}]}]}
  ```
**CI Status** https://github.com/vkatsuba/erlang/runs/2620844145