### PR TITLE
Add `IpInfoLite` to support Lite API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,22 +2,32 @@ name: CI
 
 on: [push, pull_request]
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [21.3, 22.0.7, 22.3, 23.0.4, 23.2.7.0, 24.0]
+        otp:
+          - "21.3"
+          - "22.0.7"
+          - "22.3"
+          - "23.0.4"
+          - "23.2.7.0"
+          - "24.0"
+
     container:
       image: erlang:${{ matrix.otp }}-alpine
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Compile
         run: rebar3 compile
+
+      - name: Linting
+        run: rebar3 lint
+
       - name: Tests
         run: |
           rebar3 xref

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,14 @@ jobs:
     strategy:
       matrix:
         otp:
-          - "21.3"
-          - "22.0.7"
-          - "22.3"
-          - "23.0.4"
-          - "23.2.7.0"
-          - "24.0"
+          - "21"
+          - "22"
+          - "23"
+          - "24"
+          - "25"
+          - "26"
+          - "27"
+          - "28"
 
     container:
       image: erlang:${{ matrix.otp }}-alpine
@@ -26,9 +28,13 @@ jobs:
         run: rebar3 compile
 
       - name: Linting
+        # Linting works only with latest version
+        if: ${{ matrix.otp == '28' }}
         run: rebar3 lint
 
       - name: Tests
+        env:
+          IPINFO_TOKEN: ${{ secrets.IPINFO_TOKEN }}
         run: |
           rebar3 xref
           rebar3 dialyzer

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You'll need an IPinfo API access token, which you can get by signing up for a fr
 
 The free plan is limited to 50,000 requests per month, and doesn't include some of the data fields such as IP type and company data. To enable all the data fields and additional request volumes see [https://ipinfo.io/pricing](https://ipinfo.io/pricing).
 
-⚠️ Note: This library does not currently support our newest free API https://ipinfo.io/lite. If you’d like to use IPinfo Lite, you can call the [endpoint directly](https://ipinfo.io/developers/lite-api) using your preferred HTTP client. Developers are also welcome to contribute support for Lite by submitting a pull request.
+The library also supports the Lite API, see the [Lite API section](#lite-api) for more info.
 
 ## Installation
 
@@ -60,7 +60,7 @@ Add this line to your application's `rebar.config`:
                 #{<<"code">> => <<"AF">>,<<"name">> => <<"Africa">>},
             <<"ID">> =>
                 #{<<"code">> => <<"AS">>,<<"name">> => <<"Asia">>},
-            <<"QA">> => 
+            <<"QA">> =>
                 #{<<"code">> => <<"AS">>,<<"name">> => <<"Asia">>},
             <<"LC">> =>
                 #{<<"code">> => <<"NA">>,<<"name">> => <<"North America">>},
@@ -166,7 +166,7 @@ Add this line to your application's `rebar.config`:
                   <<"unicode">> => <<"U+1F1F5 U+1F1EB">>},
             <<"CV">> =>
                 #{<<"emoji">> => <<240,159,135,168,240,159,135,187>>,
-                  <<"unicode">> => <<"U+1F1E8 U+1F1FB">>}, 
+                  <<"unicode">> => <<"U+1F1E8 U+1F1FB">>},
             <<"CG">> =>
                 #{<<"emoji">> => <<240,159,135,168,240,159,135,172>>,
                   <<"unicode">> => <<"U+1F1E8 U+1F1EC">>},
@@ -240,7 +240,7 @@ Add this line to your application's `rebar.config`:
                 #{<<"emoji">> => <<240,159,135,191,240,159,135,178>>,
                   <<"unicode">> => <<"U+1F1FF U+1F1F2">>},...},
       country_flag_base_url =>
-          <<"https://cdn.ipinfo.io/static/images/countries-flags/">>, 
+          <<"https://cdn.ipinfo.io/static/images/countries-flags/">>,
       eu_countries =>
           [<<"IE">>,<<"AT">>,<<"LT">>,<<"LU">>,<<"LV">>,<<"DE">>,
            <<"DK">>,<<"SE">>,<<"SI">>,<<"SK">>,<<"CZ">>,<<"CY">>,
@@ -313,6 +313,23 @@ def current_ip() do
     |> :inet_parse.address()
   end
 end
+```
+
+## Lite API
+
+The library gives the possibility to use the [Lite API](https://ipinfo.io/developers/lite-api) too, authentication with your token is still required.
+
+The returned details are slightly different from the Core API.
+
+```erlang
+Token = <<"TOKEN">>.
+{ok, IpInfoLite} = ipinfo_lite:create(Token).
+{ok, #{
+    <<"country_code">> := CountryCode,
+    <<"country">> := Country
+} } = ipinfo_lite:details(IpInfoLite, <<"8.8.8.8">>).
+io:format(CountryCode). %% US
+io:format(Country). %% United States
 ```
 
 ## Other Libraries

--- a/config/test.config
+++ b/config/test.config
@@ -1,5 +1,3 @@
 [
-    {ipinfo, [
-        {base_url, <<"http://localhost:32002">>}
-    ]}
+    {ipinfo, []}
 ].

--- a/elvis.config
+++ b/elvis.config
@@ -7,7 +7,7 @@
                 ruleset => erl_files,
                 rules   => [
                     {elvis_style, function_naming_convention, #{
-                        ignore => [ipinfo],
+                        ignore => [ipinfo, ipinfo_lite],
                         regex => "^([a-z][a-z0-9]*_?)*$"
                     }}
                 ]

--- a/src/ipinfo_lite.erl
+++ b/src/ipinfo_lite.erl
@@ -1,0 +1,285 @@
+-module(ipinfo_lite).
+-include_lib("kernel/include/logger.hrl").
+
+-export([
+    '__struct__'/0,
+    '__struct__'/1
+]).
+
+-export([
+    create/0,
+    create/1,
+    create/2,
+    details/1,
+    details/2
+]).
+
+-define(DEFAULT_COUNTRY_FILE, "countries.json").
+-define(DEFAULT_EU_COUNTRY_FILE, "eu.json").
+-define(DEFAULT_COUNTRY_FLAG_FILE, "flags.json").
+-define(DEFAULT_COUNTRY_CURRENCY_FILE, "currency.json").
+-define(DEFAULT_CONTINENT_FILE, "continent.json").
+-define(DEFAULT_COUNTRY_FLAG_BASE_URL,
+        <<"https://cdn.ipinfo.io/static/images/countries-flags/">>).
+-define(DEFAULT_BASE_URL, <<"https://api.ipinfo.io/lite">>).
+-define(DEFAULT_TIMEOUT, timer:seconds(5)).
+-define(DEFAULT_CACHE_TTL_SECONDS, 24 * 60 * 60).
+
+-export_type([t/0]).
+
+-type t() ::
+    #{'__struct__' := ?MODULE,
+      access_token := nil | binary(),
+      base_url := nil | binary(),
+      timeout := nil | timeout(),
+      cache := nil | pid(),
+      countries := map(),
+      countries_flags := map(),
+      country_flag_base_url := nil | binary(),
+      countries_currencies := map(),
+      continents := map(),
+      eu_countries := list()}.
+
+-spec new() -> t().
+%% @private
+new() ->
+    #{'__struct__' => ?MODULE,
+      access_token => nil,
+      base_url => nil,
+      timeout => nil,
+      cache => nil,
+      countries => #{},
+      countries_currencies => #{},
+      countries_flags => #{},
+      country_flag_base_url => nil,
+      continents => #{},
+      eu_countries => []}.
+
+-spec '__struct__'() -> t().
+%% @private
+'__struct__'() ->
+    new().
+
+-spec '__struct__'(From :: list() | map()) -> t().
+%% @private
+'__struct__'(From) ->
+    new(From).
+
+-spec new(From :: list() | map()) -> t().
+%% @private
+new(List) when is_list(List) ->
+    new(maps:from_list(List));
+new(Map) when is_map(Map) ->
+    maps:fold(fun maps:update/3, new(), Map).
+
+create() ->
+    create(application:get_env(ipinfo, access_token, nil)).
+
+create(AccessToken) when is_list(AccessToken) ->
+    create(list_to_binary(AccessToken));
+create(AccessToken) ->
+    create(AccessToken, []).
+
+-spec create(AccessToken, Settings) -> Result when
+    AccessToken :: binary() | nil,
+    Settings    :: proplists:proplist(),
+    Result      :: {ok, t()} | {error, term()}.
+create(AccessToken, Settings) ->
+    CountriesFile = get_config(countries, Settings,
+        filename:join(code:priv_dir(ipinfo), ?DEFAULT_COUNTRY_FILE)),
+    EuCountriesFile = get_config(eu_countries, Settings,
+        filename:join(code:priv_dir(ipinfo), ?DEFAULT_EU_COUNTRY_FILE)),
+    CountriesFlagsFile = get_config(countries_flags, Settings,
+        filename:join(code:priv_dir(ipinfo), ?DEFAULT_COUNTRY_FLAG_FILE)),
+    CountriesCurrenciesFile = get_config(countries_currencies, Settings,
+        filename:join(code:priv_dir(ipinfo), ?DEFAULT_COUNTRY_CURRENCY_FILE)),
+    ContinentsFile = get_config(continents, Settings,
+        filename:join(code:priv_dir(ipinfo), ?DEFAULT_CONTINENT_FILE)),
+    CountryFlagBaseUrl = get_config(country_flag_base_url, Settings,
+        ?DEFAULT_COUNTRY_FLAG_BASE_URL),
+    BaseUrl = get_config(base_url, Settings, ?DEFAULT_BASE_URL),
+    Timeout = get_config(timeout, Settings, ?DEFAULT_TIMEOUT),
+    CacheTtl = get_config(cache_ttl, Settings, ?DEFAULT_CACHE_TTL_SECONDS),
+    create_with_files(AccessToken, BaseUrl, Timeout, CacheTtl, CountriesFile,
+        EuCountriesFile, CountriesFlagsFile, CountriesCurrenciesFile,
+        ContinentsFile, CountryFlagBaseUrl).
+
+create_with_files(AccessToken, BaseUrl, Timeout, CacheTtl, CountriesFile,
+    EuCountriesFile, CountriesFlagsFile, CountriesCurrenciesFile,
+    ContinentsFile, CountryFlagBaseUrl) ->
+    Files = [
+        CountriesFile,
+        EuCountriesFile,
+        CountriesFlagsFile,
+        CountriesCurrenciesFile,
+        ContinentsFile
+    ],
+    case read_json_files(Files) of
+        {ok, [Countries, EuCountries, CountriesFlags, CountriesCurrencies, Continents]} ->
+            create_ipinfo_lite_struct(
+                AccessToken,
+                BaseUrl,
+                Timeout,
+                CacheTtl,
+                Countries,
+                EuCountries,
+                CountriesFlags,
+                CountriesCurrencies,
+                Continents,
+                CountryFlagBaseUrl
+            );
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+read_json_files(Files) ->
+    read_json_files(Files, []).
+
+read_json_files([], Acc) ->
+    {ok, lists:reverse(Acc)};
+read_json_files([File | Rest], Acc) ->
+    case read_json(File) of
+        {ok, Data} ->
+            read_json_files(Rest, [Data | Acc]);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+create_ipinfo_lite_struct(AccessToken, BaseUrl, Timeout, CacheTtl, Countries,
+    EuCountries, CountriesFlags, CountriesCurrencies, Continents,
+    CountryFlagBaseUrl) ->
+    {ok, Cache} = ipinfo_cache:create(CacheTtl),
+    {ok, new(#{
+        access_token          => AccessToken,
+        base_url              => BaseUrl,
+        timeout               => Timeout,
+        cache                 => Cache,
+        countries             => Countries,
+        eu_countries          => EuCountries,
+        countries_flags       => CountriesFlags,
+        country_flag_base_url => CountryFlagBaseUrl,
+        countries_currencies  => CountriesCurrencies,
+        continents            => Continents
+    })}.
+
+details(IpInfoLite) ->
+    details(IpInfoLite, nil).
+
+details(#{cache := Cache,
+    countries := Countries,
+    eu_countries := EuCountries,
+    countries_flags := CountriesFlags,
+    country_flag_base_url:= CountryFlagBaseUrl,
+    countries_currencies := CountriesCurrencies,
+    continents := Continents
+} = IpInfo, IpAddress) ->
+    ActualIpAddress = case IpAddress of
+        nil -> <<"me">>;
+        _ -> IpAddress
+    end,
+    case get_details(Cache, IpInfo, ActualIpAddress) of
+        {ok, Details} ->
+            {ok, enrich_details(Details, Countries, EuCountries,
+                CountriesFlags, CountryFlagBaseUrl, CountriesCurrencies,
+                Continents)};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+get_details(Cache, IpInfo, IpAddress) ->
+    case ipinfo_cache:get(Cache, IpAddress) of
+        {ok, Details} ->
+            {ok, Details};
+        error ->
+            case ipinfo_http:request_details(IpInfo, IpAddress) of
+                {ok, Details} ->
+                    ok = ipinfo_cache:add(Cache, IpAddress, Details),
+                    {ok, Details};
+                {error, Reason} ->
+                    {error, Reason}
+            end
+    end.
+
+enrich_details(Details, Countries, EuCountries, CountriesFlags,
+    CountryFlagBaseUrl, CountriesCurrencies, Continents) ->
+    Enrichers = [
+        fun(D) -> put_continent(D, Continents) end,
+        fun(D) -> put_country_currency(D, CountriesCurrencies) end,
+        fun(D) -> put_country_flag(D, CountriesFlags) end,
+        fun(D) -> put_country_flag_url(D, CountryFlagBaseUrl) end,
+        fun(D) -> put_is_eu(D, EuCountries) end,
+        fun(D) -> put_country_name(D, Countries) end
+    ],
+    lists:foldl(fun(F, Acc) -> F(Acc) end, Details, Enrichers).
+
+put_country_name(#{country := CountryCode} = Details, Countries) ->
+    case maps:find(CountryCode, Countries) of
+        {ok, CountryName} ->
+            maps:put(country_name, CountryName, Details);
+        error ->
+            Details
+    end;
+put_country_name(Details, _Countries) ->
+    Details.
+
+put_country_flag(#{country := CountryCode} = Details, CountriesFlags) ->
+    case maps:find(CountryCode, CountriesFlags) of
+        {ok, CountryFlag} ->
+            maps:put(country_flag, CountryFlag, Details);
+        error ->
+            Details
+    end;
+put_country_flag(Details, _CountriesFlags) ->
+    Details.
+
+put_country_flag_url(#{country := CountryCode} = Details, CountryFlagBaseUrl) ->
+    CountryFlagUrl = filename:join(CountryFlagBaseUrl, binary_to_list(CountryCode) ++ ".svg"),
+    maps:put(country_flag_url, CountryFlagUrl, Details);
+put_country_flag_url(Details, _CountryFlagBaseUrl) ->
+    Details.
+
+put_country_currency(#{country := CountryCode} = Details, CountriesCurrencies) ->
+    case maps:find(CountryCode, CountriesCurrencies) of
+        {ok, CountryCurrency} ->
+            maps:put(country_currency, CountryCurrency, Details);
+        error ->
+            Details
+    end;
+put_country_currency(Details, _CountriesCurrencies) ->
+    Details.
+
+put_is_eu(#{country := CountryCode} = Details, EuCountries) ->
+    case lists:member(CountryCode, EuCountries) of
+        true ->
+            maps:put(is_eu, true, Details);
+        false ->
+            maps:put(is_eu, false, Details)
+    end;
+put_is_eu(Details, _EuCountries) ->
+    Details.
+
+put_continent(#{country := CountryCode} = Details, Continents) ->
+    case maps:find(CountryCode, Continents) of
+        {ok, Continent} ->
+            maps:put(continent, Continent, Details);
+        error ->
+            Details
+    end;
+put_continent(Details, _Continents) ->
+    Details.
+
+get_config(Key, Settings, Default) ->
+    proplists:get_value(Key, Settings, application:get_env(ipinfo, Key, Default)).
+
+read_json(JsonFile) ->
+    case file:read_file(JsonFile) of
+        {ok, Binary} ->
+            case jsx:is_json(Binary) of
+                true ->
+                    {ok, jsx:decode(Binary, [return_maps])};
+                false ->
+                    {error, invalid_json}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.

--- a/test/ipinfo_SUITE.erl
+++ b/test/ipinfo_SUITE.erl
@@ -13,53 +13,91 @@
     details_test/1
 ]).
 
--define(DETAILS, #{
-    ip => <<"176.106.253.152">>,
-    city => <<"Mytishchi">>,
-    region => <<"Moscow Oblast">>,
-    country => <<"RU">>,
-    loc => <<"55.9116,37.7308">>,
-    org => <<"AS57712 NPF SOFTVIDEO Ltd.">>,
-    postal => <<"141000">>,
-    timezone => <<"Europe/Moscow">>
-}).
--define(API_TOKEN, "29a75d15").
-
 all() ->
     [details_test].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(ipinfo),
-    {ok, _} = bookish_spork:start_server(),
-    Config.
+    Token = case os:getenv("IPINFO_TOKEN") of
+        false -> nil;
+        TokenStr -> list_to_binary(TokenStr)
+    end,
+    [{token, Token} | Config].
 
 end_per_suite(_Config) ->
-    ok = bookish_spork:stop_server(),
     ok = application:stop(ipinfo).
 
-details_test(_Config) ->
-    ok = bookish_spork:stub_request([200, [], jsx:encode(?DETAILS)]),
-    {ok, IpInfo} = ipinfo:create(?API_TOKEN),
+details_test(Config) ->
+    Token = proplists:get_value(token, Config),
+    {ok, IpInfo} = ipinfo:create(Token),
     {ok, #{
-        country_name := <<"Russia">>,
-        latitude     := <<"55.9116">>,
-        longitude    := <<"37.7308">>,
-        is_eu        := false,
+        ip := <<"8.8.8.8">>,
+        loc := <<"37.4056,-122.0775">>,
+        hostname := <<"dns.google">>,
+        city := <<"Mountain View">>,
+        region := <<"California">>,
+        country := <<"US">>,
+        org := <<"AS15169 Google LLC">>,
+        postal := <<"94043">>,
+        timezone := <<"America/Los_Angeles">>,
+        country_name := <<"United States">>,
+        latitude := <<"37.4056">>,
+        longitude := <<"-122.0775">>,
+        is_eu := false,
         country_flag := #{
-            <<"emoji">>   := <<240,159,135,183,240,159,135,186>>,
-            <<"unicode">> := <<"U+1F1F7 U+1F1FA">>
+            <<"emoji">> := <<240,159,135,186,240,159,135,184>>,
+            <<"unicode">> := <<"U+1F1FA U+1F1F8">>
         },
         country_currency := #{
-            <<"code">>   := <<"RUB">>,
-            <<"symbol">> := <<226,130,189>>
+            <<"code">> := <<"USD">>,
+            <<"symbol">> := <<"$">>
         },
         continent := #{
-            <<"code">> := <<"EU">>,
-            <<"name">> := <<"Europe">>
+            <<"code">> := <<"NA">>,
+            <<"name">> := <<"North America">>
+        },
+        country_flag_url := <<"https:/cdn.ipinfo.io/static/images/countries-flags/US.svg">>,
+        is_anonymous := false,
+        <<"abuse">> := #{
+            name := <<"Abuse">>,
+            address := <<"US, CA, Mountain View, 1600 Amphitheatre Parkway, 94043">>,
+            country := <<"US">>,
+            email := <<"network-abuse@google.com">>,
+            <<"network">> := <<"8.8.8.0/24">>,
+            <<"phone">> := <<"+1-650-253-0000">>
+        },
+        <<"asn">> := #{
+            name := <<"Google LLC">>,
+            type := <<"hosting">>,
+            domain := <<"google.com">>,
+            <<"asn">> := <<"AS15169">>,
+            <<"route">> := <<"8.8.8.0/24">>
+        },
+        <<"company">> := #{
+            name := <<"Google LLC">>,
+            type := <<"hosting">>,
+            domain := <<"google.com">>
+        },
+        <<"domains">> := #{
+            total := 15669,ip := <<"8.8.8.8">>,
+            <<"domains">> :=[
+                <<"hdchina.org">>,
+                <<"musicool.cn">>,
+                <<"ztgg.org">>,
+                <<"itempurl.com">>,
+                <<"authrock.com">>
+            ]
+        },
+        <<"is_anycast">> := true,
+        <<"is_hosting">> := true,
+        <<"is_mobile">> := false,
+        <<"is_satellite">> := false,
+        <<"privacy">> := #{
+            service := <<>>,
+            proxy := false,
+            relay := false,
+            <<"hosting">> := true,
+            <<"tor">> := false,
+            <<"vpn">> := false
         }
-
-    }} = ipinfo:details(IpInfo, <<"176.106.253.152">>),
-    {ok, Request} = bookish_spork:capture_request(),
-    ?assertEqual(<<"/176.106.253.152">>, bookish_spork_request:uri(Request)),
-    ?assertEqual(<<"Bearer ", ?API_TOKEN>>,
-        bookish_spork_request:header(Request, <<"Authorization">>)).
+    }} = ipinfo:details(IpInfo, <<"8.8.8.8">>).

--- a/test/ipinfo_lite_SUITE.erl
+++ b/test/ipinfo_lite_SUITE.erl
@@ -1,0 +1,95 @@
+-module(ipinfo_lite_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-export([
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    details_ip_v4_test/1,
+    details_ip_v6_test/1,
+    details_current_ip_test/1
+]).
+
+all() ->
+    [
+        details_ip_v4_test,
+        details_ip_v6_test,
+        details_current_ip_test
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(ipinfo),
+    Token =
+        case os:getenv("IPINFO_TOKEN") of
+            false ->
+                nil;
+            TokenStr ->
+                list_to_binary(TokenStr)
+        end,
+    [{token, Token} | Config].
+
+end_per_suite(_Config) ->
+    ok = application:stop(ipinfo).
+
+details_ip_v4_test(Config) ->
+    Token = proplists:get_value(token, Config),
+    {ok, IpInfoLite} = ipinfo_lite:create(Token),
+    {ok, #{
+        ip := <<"8.8.8.8">>,
+        is_eu := false,
+        country_flag_url := <<"https:/cdn.ipinfo.io/static/images/countries-flags/United States.svg">>,
+        country := <<"United States">>,
+        continent := <<"North America">>,
+        <<"as_domain">> := <<"google.com">>,
+        <<"as_name">> := <<"Google LLC">>,
+        <<"asn">> := <<"AS15169">>,
+        <<"continent_code">> := <<"NA">>,
+        <<"country_code">> := <<"US">>}
+    } = ipinfo_lite:details(IpInfoLite, <<"8.8.8.8">>).
+
+details_ip_v6_test(Config) ->
+    Token = proplists:get_value(token, Config),
+    {ok, IpInfoLite} = ipinfo_lite:create(Token),
+    {ok, #{
+        ip := <<"2001:4860:4860::8888">>,
+        is_eu := false,
+        country_flag_url := <<"https:/cdn.ipinfo.io/static/images/countries-flags/United States.svg">>,
+        country := <<"United States">>,
+        continent := <<"North America">>,
+        <<"as_domain">> := <<"google.com">>,
+        <<"as_name">> := <<"Google LLC">>,
+        <<"asn">> := <<"AS15169">>,
+        <<"continent_code">> := <<"NA">>,
+        <<"country_code">> := <<"US">>}
+    } = ipinfo_lite:details(IpInfoLite, <<"2001:4860:4860::8888">>).
+
+details_current_ip_test(Config) ->
+    Token = proplists:get_value(token, Config),
+    {ok, IpInfoLite} = ipinfo_lite:create(Token),
+    {ok, #{
+        ip := Ip,
+        is_eu := IsEu,
+        country_flag_url := CountryFlagUrl,
+        country := Country,
+        continent := Continent,
+        <<"as_domain">> := AsDomain,
+        <<"as_name">> := AsName,
+        <<"asn">> := Asn,
+        <<"continent_code">> := ContinentCode,
+        <<"country_code">> := CountryCode}
+    } = ipinfo_lite:details(IpInfoLite),
+    ?assertNotEqual(nil, Ip),
+    ?assertNotEqual(nil, IsEu),
+    ?assertNotEqual(nil, CountryFlagUrl),
+    ?assertNotEqual(nil, Country),
+    ?assertNotEqual(nil, Continent),
+    ?assertNotEqual(nil, AsDomain),
+    ?assertNotEqual(nil, AsName),
+    ?assertNotEqual(nil, Asn),
+    ?assertNotEqual(nil, ContinentCode),
+    ?assertNotEqual(nil, CountryCode).


### PR DESCRIPTION
Usual approach as other libraries.

I had to change the existing tests as they were using a local mocked server thus stopping me from testing the actual new endpoints. 

I also added more versions in the CI workflow to add linting and removed some unnecessary stuff like the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` env var.

Because of linting I had to change some code in the existing implementation to fix the errors.