### PR TITLE
`details_test`: update 8.8.8.8 details

### DIFF
--- a/test/ipinfo_SUITE.erl
+++ b/test/ipinfo_SUITE.erl
@@ -30,74 +30,72 @@ end_per_suite(_Config) ->
 details_test(Config) ->
     Token = proplists:get_value(token, Config),
     {ok, IpInfo} = ipinfo:create(Token),
-    {ok, #{
-        ip := <<"8.8.8.8">>,
-        loc := <<"37.4056,-122.0775">>,
-        hostname := <<"dns.google">>,
-        city := <<"Mountain View">>,
-        region := <<"California">>,
-        country := <<"US">>,
-        org := <<"AS15169 Google LLC">>,
-        postal := <<"94043">>,
-        timezone := <<"America/Los_Angeles">>,
-        country_name := <<"United States">>,
-        latitude := <<"37.4056">>,
-        longitude := <<"-122.0775">>,
-        is_eu := false,
-        country_flag := #{
-            <<"emoji">> := <<240,159,135,186,240,159,135,184>>,
-            <<"unicode">> := <<"U+1F1FA U+1F1F8">>
-        },
-        country_currency := #{
-            <<"code">> := <<"USD">>,
-            <<"symbol">> := <<"$">>
-        },
-        continent := #{
-            <<"code">> := <<"NA">>,
-            <<"name">> := <<"North America">>
-        },
-        country_flag_url := <<"https:/cdn.ipinfo.io/static/images/countries-flags/US.svg">>,
-        is_anonymous := false,
-        <<"abuse">> := #{
-            name := <<"Abuse">>,
-            address := <<"US, CA, Mountain View, 1600 Amphitheatre Parkway, 94043">>,
-            country := <<"US">>,
-            email := <<"network-abuse@google.com">>,
-            <<"network">> := <<"8.8.8.0/24">>,
-            <<"phone">> := <<"+1-650-253-0000">>
-        },
-        <<"asn">> := #{
-            name := <<"Google LLC">>,
-            type := <<"hosting">>,
-            domain := <<"google.com">>,
-            <<"asn">> := <<"AS15169">>,
-            <<"route">> := <<"8.8.8.0/24">>
-        },
-        <<"company">> := #{
-            name := <<"Google LLC">>,
-            type := <<"hosting">>,
-            domain := <<"google.com">>
-        },
-        <<"domains">> := #{
-            total := 15669,ip := <<"8.8.8.8">>,
-            <<"domains">> :=[
-                <<"hdchina.org">>,
-                <<"musicool.cn">>,
-                <<"ztgg.org">>,
-                <<"itempurl.com">>,
-                <<"authrock.com">>
-            ]
-        },
-        <<"is_anycast">> := true,
-        <<"is_hosting">> := true,
-        <<"is_mobile">> := false,
-        <<"is_satellite">> := false,
-        <<"privacy">> := #{
-            service := <<>>,
-            proxy := false,
-            relay := false,
-            <<"hosting">> := true,
-            <<"tor">> := false,
-            <<"vpn">> := false
-        }
-    }} = ipinfo:details(IpInfo, <<"8.8.8.8">>).
+    {ok, Details}= ipinfo:details(IpInfo, <<"8.8.8.8">>),
+    ?assertEqual(<<"Mountain View">>, maps:get(city, Details)),
+    ?assertEqual(#{
+        <<"code">> => <<"NA">>,
+        <<"name">> => <<"North America">>
+    }, maps:get(continent, Details)),
+    ?assertEqual(<<"US">>, maps:get(country, Details)),
+    ?assertEqual(#{
+        <<"code">> => <<"USD">>,
+        <<"symbol">> => <<"$">>
+    }, maps:get(country_currency, Details)),
+    ?assertEqual(#{
+        <<"emoji">> => <<240,159,135,186,240,159,135,184>>,
+        <<"unicode">> => <<"U+1F1FA U+1F1F8">>
+    }, maps:get(country_flag, Details)),
+    ?assertEqual(<<"https:/cdn.ipinfo.io/static/images/countries-flags/US.svg">>, maps:get(country_flag_url, Details)),
+    ?assertEqual(<<"United States">>, maps:get(country_name, Details)),
+    ?assertEqual(<<"dns.google">>, maps:get(hostname, Details)),
+    ?assertEqual(<<"8.8.8.8">>, maps:get(ip, Details)),
+    ?assertEqual(false, maps:get(is_anonymous, Details)),
+    ?assertEqual(false, maps:get(is_eu, Details)),
+    ?assertEqual(<<"38.0088">>, maps:get(latitude, Details)),
+    ?assertEqual(<<"38.0088,-122.1175">>, maps:get(loc, Details)),
+    ?assertEqual(<<"-122.1175">>, maps:get(longitude, Details)),
+    ?assertEqual(<<"AS15169 Google LLC">>, maps:get(org, Details)),
+    ?assertEqual(<<"94043">>, maps:get(postal, Details)),
+    ?assertEqual(<<"California">>, maps:get(region, Details)),
+    ?assertEqual(<<"America/Los_Angeles">>, maps:get(timezone, Details)),
+    ?assertEqual(#{ 
+        address => <<"US, CA, Mountain View, 1600 Amphitheatre Parkway, 94043">>,
+        country => <<"US">>,
+        email => <<"network-abuse@google.com">>,
+        name => <<"Abuse">>,<<"network">> => <<"8.8.8.0/24">>,
+        <<"phone">> => <<"+1-650-253-0000">>
+    }, maps:get(<<"abuse">>, Details)),
+    ?assertEqual(#{
+        domain => <<"google.com">>,
+        name => <<"Google LLC">>,
+        type => <<"hosting">>,
+        <<"asn">> => <<"AS15169">>,
+        <<"route">> => <<"8.8.8.0/24">>
+    }, maps:get(<<"asn">>, Details)),
+    ?assertEqual(#{ 
+        domain => <<"google.com">>,
+        name => <<"Google LLC">>,
+        type => <<"hosting">>
+    }, maps:get(<<"company">>, Details)),
+    ?assertEqual(#{ 
+        ip => <<"8.8.8.8">>,
+        total => 15669,
+        <<"domains">> => [
+            <<"hdchina.org">>,
+            <<"musicool.cn">>,
+            <<"ztgg.org">>,
+            <<"itempurl.com">>,
+            <<"authrock.com">>]
+    }, maps:get(<<"domains">>, Details)),
+    ?assertEqual(true, maps:get(<<"is_anycast">>, Details)),
+    ?assertEqual(true, maps:get(<<"is_hosting">>, Details)),
+    ?assertEqual(false, maps:get(<<"is_mobile">>, Details)),
+    ?assertEqual(false, maps:get(<<"is_satellite">>, Details)),
+    ?assertEqual(#{
+        proxy => false,
+        relay => false,
+        service => <<>>,
+        <<"hosting">> => true,
+        <<"tor">> => false,
+        <<"vpn">> => false
+    }, maps:get(<<"privacy">>, Details)).


### PR DESCRIPTION
Rewrote test so that every field of `ipinfo:details` could be checked individually, making the resolution of single errors easier to manage.