### PR TITLE
Fix parsing of Lite API response

### DIFF
--- a/src/ipinfo_lite.erl
+++ b/src/ipinfo_lite.erl
@@ -212,17 +212,17 @@ enrich_details(Details, Countries, EuCountries, CountriesFlags,
     ],
     lists:foldl(fun(F, Acc) -> F(Acc) end, Details, Enrichers).
 
-put_country_name(#{country := CountryCode} = Details, Countries) ->
+put_country_name(#{country_code := CountryCode} = Details, Countries) ->
     case maps:find(CountryCode, Countries) of
         {ok, CountryName} ->
-            maps:put(country_name, CountryName, Details);
+            maps:put(country, CountryName, Details);
         error ->
             Details
     end;
 put_country_name(Details, _Countries) ->
     Details.
 
-put_country_flag(#{country := CountryCode} = Details, CountriesFlags) ->
+put_country_flag(#{country_code := CountryCode} = Details, CountriesFlags) ->
     case maps:find(CountryCode, CountriesFlags) of
         {ok, CountryFlag} ->
             maps:put(country_flag, CountryFlag, Details);
@@ -232,13 +232,13 @@ put_country_flag(#{country := CountryCode} = Details, CountriesFlags) ->
 put_country_flag(Details, _CountriesFlags) ->
     Details.
 
-put_country_flag_url(#{country := CountryCode} = Details, CountryFlagBaseUrl) ->
-    CountryFlagUrl = filename:join(CountryFlagBaseUrl, binary_to_list(CountryCode) ++ ".svg"),
+put_country_flag_url(#{country_code := CountryCode} = Details, CountryFlagBaseUrl) ->
+    CountryFlagUrl = <<CountryFlagBaseUrl/binary, CountryCode/binary, ".svg">>,
     maps:put(country_flag_url, CountryFlagUrl, Details);
 put_country_flag_url(Details, _CountryFlagBaseUrl) ->
     Details.
 
-put_country_currency(#{country := CountryCode} = Details, CountriesCurrencies) ->
+put_country_currency(#{country_code := CountryCode} = Details, CountriesCurrencies) ->
     case maps:find(CountryCode, CountriesCurrencies) of
         {ok, CountryCurrency} ->
             maps:put(country_currency, CountryCurrency, Details);
@@ -248,7 +248,7 @@ put_country_currency(#{country := CountryCode} = Details, CountriesCurrencies) -
 put_country_currency(Details, _CountriesCurrencies) ->
     Details.
 
-put_is_eu(#{country := CountryCode} = Details, EuCountries) ->
+put_is_eu(#{country_code := CountryCode} = Details, EuCountries) ->
     case lists:member(CountryCode, EuCountries) of
         true ->
             maps:put(is_eu, true, Details);
@@ -258,11 +258,13 @@ put_is_eu(#{country := CountryCode} = Details, EuCountries) ->
 put_is_eu(Details, _EuCountries) ->
     Details.
 
-put_continent(#{country := CountryCode} = Details, Continents) ->
+put_continent(#{country_code := CountryCode} = Details, Continents) ->
     case maps:find(CountryCode, Continents) of
-        {ok, Continent} ->
+        {ok, #{<<"name">> := ContinentName}} ->
+            maps:put(continent, ContinentName, Details);
+        {ok, Continent} when is_binary(Continent) ->
             maps:put(continent, Continent, Details);
-        error ->
+        _ ->
             Details
     end;
 put_continent(Details, _Continents) ->

--- a/test/ipinfo_SUITE.erl
+++ b/test/ipinfo_SUITE.erl
@@ -69,9 +69,9 @@ details_test(Config) ->
         domain => <<"google.com">>,
         name => <<"Google LLC">>,
         type => <<"hosting">>,
-        <<"asn">> => <<"AS15169">>,
-        <<"route">> => <<"8.8.8.0/24">>
-    }, maps:get(<<"asn">>, Details)),
+        asn => <<"AS15169">>,
+        route => <<"8.8.8.0/24">>
+    }, maps:get(asn, Details)),
     Company = maps:get(<<"company">>, Details),
     ?assertEqual(<<"google.com">>, maps:get(domain, Company)),
     ?assertEqual(<<"Google LLC">>, maps:get(name, Company)),

--- a/test/ipinfo_lite_SUITE.erl
+++ b/test/ipinfo_lite_SUITE.erl
@@ -39,57 +39,44 @@ end_per_suite(_Config) ->
 details_ip_v4_test(Config) ->
     Token = proplists:get_value(token, Config),
     {ok, IpInfoLite} = ipinfo_lite:create(Token),
-    {ok, #{
-        ip := <<"8.8.8.8">>,
-        is_eu := false,
-        country_flag_url := <<"https:/cdn.ipinfo.io/static/images/countries-flags/United States.svg">>,
-        country := <<"United States">>,
-        continent := <<"North America">>,
-        <<"as_domain">> := <<"google.com">>,
-        <<"as_name">> := <<"Google LLC">>,
-        <<"asn">> := <<"AS15169">>,
-        <<"continent_code">> := <<"NA">>,
-        <<"country_code">> := <<"US">>}
-    } = ipinfo_lite:details(IpInfoLite, <<"8.8.8.8">>).
+    {ok, Details} = ipinfo_lite:details(IpInfoLite, <<"8.8.8.8">>),
+    ?assertEqual(<<"8.8.8.8">>, maps:get(ip, Details)),
+    ?assertEqual(<<"US">>, maps:get(country_code, Details)),
+    ?assertEqual(<<"United States">>, maps:get(country, Details)),
+    ?assertEqual(false, maps:get(is_eu, Details)),
+    ?assertEqual(<<"https://cdn.ipinfo.io/static/images/countries-flags/US.svg">>, maps:get(country_flag_url, Details)),
+    ?assertEqual(<<"North America">>, maps:get(continent, Details)),
+    ?assertEqual(<<"NA">>, maps:get(continent_code, Details)),
+    ?assertEqual(<<"AS15169">>, maps:get(asn, Details)),
+    ?assertEqual(<<"google.com">>, maps:get(<<"as_domain">>, Details)),
+    ?assertEqual(<<"Google LLC">>, maps:get(<<"as_name">>, Details)).
 
 details_ip_v6_test(Config) ->
     Token = proplists:get_value(token, Config),
     {ok, IpInfoLite} = ipinfo_lite:create(Token),
-    {ok, #{
-        ip := <<"2001:4860:4860::8888">>,
-        is_eu := false,
-        country_flag_url := <<"https:/cdn.ipinfo.io/static/images/countries-flags/United States.svg">>,
-        country := <<"United States">>,
-        continent := <<"North America">>,
-        <<"as_domain">> := <<"google.com">>,
-        <<"as_name">> := <<"Google LLC">>,
-        <<"asn">> := <<"AS15169">>,
-        <<"continent_code">> := <<"NA">>,
-        <<"country_code">> := <<"US">>}
-    } = ipinfo_lite:details(IpInfoLite, <<"2001:4860:4860::8888">>).
+    {ok, Details} = ipinfo_lite:details(IpInfoLite, <<"2001:4860:4860::8888">>),
+    ?assertEqual(<<"2001:4860:4860::8888">>, maps:get(ip, Details)),
+    ?assertEqual(<<"US">>, maps:get(country_code, Details)),
+    ?assertEqual(<<"United States">>, maps:get(country, Details)),
+    ?assertEqual(false, maps:get(is_eu, Details)),
+    ?assertEqual(<<"https://cdn.ipinfo.io/static/images/countries-flags/US.svg">>, maps:get(country_flag_url, Details)),
+    ?assertEqual(<<"North America">>, maps:get(continent, Details)),
+    ?assertEqual(<<"NA">>, maps:get(continent_code, Details)),
+    ?assertEqual(<<"AS15169">>, maps:get(asn, Details)),
+    ?assertEqual(<<"google.com">>, maps:get(<<"as_domain">>, Details)),
+    ?assertEqual(<<"Google LLC">>, maps:get(<<"as_name">>, Details)).
 
 details_current_ip_test(Config) ->
     Token = proplists:get_value(token, Config),
     {ok, IpInfoLite} = ipinfo_lite:create(Token),
-    {ok, #{
-        ip := Ip,
-        is_eu := IsEu,
-        country_flag_url := CountryFlagUrl,
-        country := Country,
-        continent := Continent,
-        <<"as_domain">> := AsDomain,
-        <<"as_name">> := AsName,
-        <<"asn">> := Asn,
-        <<"continent_code">> := ContinentCode,
-        <<"country_code">> := CountryCode}
-    } = ipinfo_lite:details(IpInfoLite),
-    ?assertNotEqual(nil, Ip),
-    ?assertNotEqual(nil, IsEu),
-    ?assertNotEqual(nil, CountryFlagUrl),
-    ?assertNotEqual(nil, Country),
-    ?assertNotEqual(nil, Continent),
-    ?assertNotEqual(nil, AsDomain),
-    ?assertNotEqual(nil, AsName),
-    ?assertNotEqual(nil, Asn),
-    ?assertNotEqual(nil, ContinentCode),
-    ?assertNotEqual(nil, CountryCode).
+    {ok, Details} = ipinfo_lite:details(IpInfoLite),
+    ?assertNotEqual(nil, maps:get(ip, Details)),
+    ?assertNotEqual(nil, maps:get(is_eu, Details)),
+    ?assertNotEqual(nil, maps:get(country_flag_url, Details)),
+    ?assertNotEqual(nil, maps:get(country, Details)),
+    ?assertNotEqual(nil, maps:get(continent, Details)),
+    ?assertNotEqual(nil, maps:get(<<"as_domain">>, Details)),
+    ?assertNotEqual(nil, maps:get(<<"as_name">>, Details)),
+    ?assertNotEqual(nil, maps:get(asn, Details)),
+    ?assertNotEqual(nil, maps:get(continent_code, Details)),
+    ?assertNotEqual(nil, maps:get(country_code, Details)).


### PR DESCRIPTION
The Lite API country data wasn't parsed correctly and we were returning invalid values, like the country flag URL.
This PR fixes it.

I also had to slightly change a test in `ipinfo_SUITE.erl` because now we correctly create an atom when parsing the Lite API response. Since tests are all compiled together that atom is also available to `ipinfo_SUITE.erl` tests and when `jsx:decode` is called with `attempt_atom` it converts the keys to atom instead of keeping it to binary.