### PR TITLE
Add Residential Proxy API support

### DIFF
--- a/src/ipinfo.erl
+++ b/src/ipinfo.erl
@@ -11,7 +11,8 @@
     create/1,
     create/2,
     details/1,
-    details/2
+    details/2,
+    resproxy/2
 ]).
 
 -define(DEFAULT_COUNTRY_FILE, "countries.json").
@@ -183,6 +184,22 @@ details(#{cache := Cache,
                 Continents)};
         {error, Reason} ->
             {error, Reason}
+    end.
+
+-spec resproxy(t(), binary()) -> {ok, map()} | {error, term()}.
+resproxy(#{cache := Cache} = IpInfo, IpAddress) ->
+    CacheKey = <<"resproxy:", IpAddress/binary>>,
+    case ipinfo_cache:get(Cache, CacheKey) of
+        {ok, Details} ->
+            {ok, Details};
+        error ->
+            case ipinfo_http:request_resproxy(IpInfo, IpAddress) of
+                {ok, Details} ->
+                    ok = ipinfo_cache:add(Cache, CacheKey, Details),
+                    {ok, Details};
+                {error, Reason} ->
+                    {error, Reason}
+            end
     end.
 
 get_details(Cache, IpInfo, IpAddress) ->

--- a/src/ipinfo_http.erl
+++ b/src/ipinfo_http.erl
@@ -1,7 +1,7 @@
 -module(ipinfo_http).
 -include_lib("kernel/include/logger.hrl").
 
--export([request_details/2]).
+-export([request_details/2, request_resproxy/2]).
 
 -define(RATE_LIMIT_MESSAGE, <<
     "To increase your limits, please review our ",
@@ -9,10 +9,19 @@
 >>).
 
 -spec request_details(ipinfo:t(), binary()) -> {ok, map()} | {error, term()}.
-request_details(#{access_token := AccessToken, base_url := BaseUrl, timeout := Timeout}, Ip) ->
-    Url = binary_to_list(build_url(BaseUrl, Ip)),
+request_details(#{base_url := BaseUrl} = Config, Ip) ->
+    Url = build_url(BaseUrl, Ip),
+    do_request(Config, Url).
+
+-spec request_resproxy(ipinfo:t(), binary()) -> {ok, map()} | {error, term()}.
+request_resproxy(#{base_url := BaseUrl} = Config, Ip) ->
+    Url = build_resproxy_url(BaseUrl, Ip),
+    do_request(Config, Url).
+
+-spec do_request(ipinfo:t(), binary()) -> {ok, map()} | {error, term()}.
+do_request(#{access_token := AccessToken, timeout := Timeout}, Url) ->
     ReqHeaders = build_req_headers(AccessToken),
-    Request = {Url, ReqHeaders},
+    Request = {binary_to_list(Url), ReqHeaders},
     HTTPOptions = [
         {timeout, Timeout}
     ],
@@ -39,6 +48,10 @@ build_url(BaseUrl, Ip) when Ip =:= nil orelse Ip =:= undefined ->
     BaseUrl;
 build_url(BaseUrl, Ip) when is_binary(BaseUrl) andalso is_binary(Ip) ->
     <<BaseUrl/binary, "/", Ip/binary>>.
+
+-spec build_resproxy_url(binary(), binary()) -> binary().
+build_resproxy_url(BaseUrl, Ip) when is_binary(BaseUrl) andalso is_binary(Ip) ->
+    <<BaseUrl/binary, "/resproxy/", Ip/binary>>.
 
 build_req_headers(nil) ->
     base_req_headers();

--- a/test/ipinfo_resproxy_SUITE.erl
+++ b/test/ipinfo_resproxy_SUITE.erl
@@ -1,0 +1,44 @@
+-module(ipinfo_resproxy_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-export([
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    resproxy_test/1,
+    resproxy_empty_test/1
+]).
+
+all() ->
+    [resproxy_test, resproxy_empty_test].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(ipinfo),
+    Token = case os:getenv("IPINFO_TOKEN") of
+        false -> nil;
+        TokenStr -> list_to_binary(TokenStr)
+    end,
+    [{token, Token} | Config].
+
+end_per_suite(_Config) ->
+    ok = application:stop(ipinfo).
+
+resproxy_test(Config) ->
+    Token = proplists:get_value(token, Config),
+    {ok, IpInfo} = ipinfo:create(Token),
+    {ok, Resproxy} = ipinfo:resproxy(IpInfo, <<"175.107.211.204">>),
+    ?assertEqual(<<"175.107.211.204">>, maps:get(ip, Resproxy)),
+    ?assertNotEqual(undefined, maps:get(last_seen, Resproxy)),
+    ?assertNotEqual(undefined, maps:get(percent_days_seen, Resproxy)),
+    ?assertNotEqual(undefined, maps:get(service, Resproxy)).
+
+resproxy_empty_test(Config) ->
+    Token = proplists:get_value(token, Config),
+    {ok, IpInfo} = ipinfo:create(Token),
+    {ok, Resproxy} = ipinfo:resproxy(IpInfo, <<"8.8.8.8">>),
+    ?assertEqual(#{}, Resproxy).


### PR DESCRIPTION
This PR adds support for the [Residential Proxy Detection API](https://ipinfo.io/developers/residential-proxy-api).