### PR TITLE
Update Bulgaria currency from BGN to EUR

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -1,38 +1,22 @@
 [
-    {elvis, [
-        {config, [
-            #{
-                dirs    => ["src"],
-                filter  => "*.erl",
-                ruleset => erl_files,
-                rules   => [
-                    {elvis_style, function_naming_convention, #{
-                        ignore => [ipinfo, ipinfo_lite, ipinfo_core, ipinfo_plus],
-                        regex => "^([a-z][a-z0-9]*_?)*$"
-                    }}
-                ]
-            },
-            #{
-                dirs    => ["."],
-                filter  => "Makefile",
-                ruleset => makefiles
-            },
-            #{
-                dirs    => ["."],
-                filter  => "rebar.config",
-                ruleset => rebar_config
-            },
-            #{
-                dirs    => ["."],
-                filter  => "elvis.config",
-                ruleset => elvis_config
-            }
-        ]
-      },
-      {output_format, colors},
-      {verbose, true},
-      {no_output, false},
-      {parallel, 1}
-    ]
-  }
+    {config, [
+        #{
+            files   => ["src/*.erl"],
+            ruleset => erl_files,
+            rules   => [
+                {elvis_style, function_naming_convention, #{
+                    ignore => [ipinfo, ipinfo_lite, ipinfo_core, ipinfo_plus],
+                    regex => "^([a-z][a-z0-9]*_?)*$"
+                }}
+            ]
+        },
+        #{
+            files   => ["rebar.config"],
+            ruleset => rebar_config
+        }
+    ]},
+    {output_format, colors},
+    {verbose, true},
+    {no_output, false},
+    {parallel, 1}
 ].

--- a/priv/currency.json
+++ b/priv/currency.json
@@ -20,7 +20,7 @@
     "BD" : { "code": "BDT" ,"symbol": "৳"},
     "BE" : { "code": "EUR" ,"symbol": "€"},
     "BF" : { "code": "XOF" ,"symbol": "CFA"},
-    "BG" : { "code": "BGN" ,"symbol": "лв"},
+    "BG" : { "code": "EUR" ,"symbol": "€"},
     "BH" : { "code": "BHD" ,"symbol": ".د.ب"},
     "BI" : { "code": "BIF" ,"symbol": "FBu"},
     "BJ" : { "code": "XOF" ,"symbol": "CFA"},


### PR DESCRIPTION
Bulgaria adopted the Euro starting 1/1/26, this PR changes the country currency code and symbol to reflect that.